### PR TITLE
Update react-native onnxruntime for expo compatibility

### DIFF
--- a/js/react_native/android/build.gradle
+++ b/js/react_native/android/build.gradle
@@ -1,17 +1,5 @@
 import java.nio.file.Paths
 
-buildscript {
-  repositories {
-    google()
-    mavenCentral()
-  }
-
-  dependencies {
-    classpath 'com.android.tools.build:gradle:7.4.2'
-    // noinspection DifferentKotlinGradleVersion
-  }
-}
-
 apply plugin: 'com.android.library'
 
 def getExtOrDefault(name) {

--- a/js/react_native/package.json
+++ b/js/react_native/package.json
@@ -1,5 +1,5 @@
 {
-  "react-native": "lib/index",
+  "react-native": "dist/commonjs/index",
   "module": "dist/module/index",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
### Description
Updates to `package.json`, `binding.ts`, and `android/build.gradle` to ensure `onnxruntime-react-native` is compatible with Expo.

### Motivation and Context
This change addresses several issues preventing `onnxruntime-react-native` from working correctly in Expo environments:
1.  **Metro Transpilation:** Expo/Metro does not transpile TypeScript in `node_modules`, causing build failures when the `react-native` entry pointed to `lib/index` (TS).
2.  **Native Module Access:** Prevents crashes and provides clear error messages when the native module is not installed (e.g., in Expo Go), by guarding JSI installation and native API calls.
3.  **Android Build Compatibility:** Removes a conflicting `buildscript` block in `android/build.gradle` that caused issues with `expo prebuild`.

These changes enable safe import in Expo Go and full functionality with a custom development client.

---
<a href="https://cursor.com/background-agent?bcId=bc-3246e75a-6fe9-43b4-9ab6-11a4be97f4d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3246e75a-6fe9-43b4-9ab6-11a4be97f4d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

